### PR TITLE
Add the ability to list all phases

### DIFF
--- a/moon_api.rb
+++ b/moon_api.rb
@@ -29,6 +29,15 @@ class MoonApi < Sinatra::Base
     halt_with_404_not_found
   end
 
+  # Returns all the moon phases
+  get '/phases' do
+    phases = []
+    Moon::ASSOCIATIONS.keys.map do |phase|
+      phases << Moon.new(phase:)
+    end
+    phases.to_json
+  end
+
   # Return the moon phase for a specific date as a unix epoch timestamp
   get '/date/(:date)' do
     # Just check if it's a series of digits

--- a/spec/moon_api_spec.rb
+++ b/spec/moon_api_spec.rb
@@ -54,6 +54,21 @@ describe 'MoonApi' do
     end
   end
 
+  describe '/phases' do
+    it 'returns all the moon phases' do
+      get '/phases'
+
+      expect(last_response).to be_ok
+      body = JSON.parse(last_response.body)
+
+      expect(body.length).to eq 8
+      expect(body[0]['phase']).to eq 'new'
+      expect(body[0]['days']).to eq 0
+      expect(body[0]['emoji']).to eq '🌑'
+      expect(body[0]['association']).to eq 'new beginnings'
+    end
+  end
+
   describe '/date/:date' do
     it 'returns the moon phase for a specific date' do
       get '/date/1535750400'


### PR DESCRIPTION
This pull request introduces a new feature to the `moon_api.rb` file and adds corresponding tests in the `spec/moon_api_spec.rb` file. The new feature allows users to fetch all the moon phases. The changes also include a new test case to verify the functionality of this feature.